### PR TITLE
Template the `yamlApplicationConfig` value

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/configmap_fromValues.yaml
+++ b/charts/kafka-ui/templates/configmap_fromValues.yaml
@@ -8,5 +8,5 @@ metadata:
     {{- include "kafka-ui.labels" . | nindent 4 }}
 data:
   config.yml: |-
-    {{- toYaml .Values.yamlApplicationConfig | nindent 4}}
+    {{- tpl (toYaml .Values.yamlApplicationConfig) . | nindent 4}}
 {{ end }}


### PR DESCRIPTION
This allows `yamlApplicationConfig` to include references to other values.

For example, if I have a value the determines the ingress host `global.ingressHost` and I want to set the OAuth2 parameters in the `yamlApplicationConfig` I could do something like

```yaml
global:
  ingressHost: mywebsite.com

yamlApplicationConfig:
  auth:
    type: OAUTH2
    oauth2:
      client:
        keycloak:
          clientId: xxx
          clientSecret: yyy
          scope: opened
          issuer-uri: "https://{{ .Values.global.ingressHost }}/auth/realms/<realm>"
          user-name-attribute: preferred_username
          client-name: keycloak
          provider: keycloak
          custom-params:
            type: oauth
```

By changing `global.ingressHost`, the configuration for kafbat UI automatically changes to fit the new issuer-uri. Without this change, I'd have to duplicate the host configuration like

```yaml
global:
  ingressHost: mywebsite.com

yamlApplicationConfig:
  auth:
    type: OAUTH2
    oauth2:
      client:
        keycloak:
          clientId: xxx
          clientSecret: yyy
          scope: opened
          issuer-uri: "https://mywebsite.com/auth/realms/<realm>"
          user-name-attribute: preferred_username
          client-name: keycloak
          provider: keycloak
          custom-params:
            type: oauth
```

This is very helpful when kafbat UI is a subchart of another chart.

This is strictly an enhancement, there are no breaking changes.