### PR TITLE
Add hostAliases to template

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -149,3 +149,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -161,3 +161,5 @@ initContainers: {}
 volumeMounts: {}
 
 volumes: {}
+
+hostAliases: {}


### PR DESCRIPTION
This enables hostAliases to be configured.
https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/

Is for example useful when working with a sidecard proxy. The values configuration could look something like this:
```yaml
hostAliases:
  - ip: "127.0.0.1"
    hostnames:
      - "schema-registry.localhost"
```