### PR TITLE
Add ability to pass configuration from secret

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -48,17 +48,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "kafka-ui.imageName" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.env  .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap}}
+          {{- if or .Values.env  .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
           env:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if or .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap}}
+            {{- if or .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
             - name: SPRING_CONFIG_ADDITIONAL-LOCATION
               {{- if .Values.yamlApplicationConfig }}
               value: /kafka-ui/config.yml
               {{- else if .Values.yamlApplicationConfigConfigMap }}
               value: /kafka-ui/{{ .Values.yamlApplicationConfigConfigMap.keyName | default "config.yml" }}
+              {{- else if .Values.yamlApplicationConfigSecret }}
+              value: /kafka-ui/{{ .Values.yamlApplicationConfigSecret.keyName | default "config.yml" }}
               {{- end }}
             {{- end }}
           {{- end }}
@@ -107,7 +109,7 @@ spec:
             timeoutSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap}}
+          {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
           volumeMounts:
             {{- with .Values.volumeMounts }} 
               {{- toYaml . | nindent 12 }}
@@ -120,8 +122,12 @@ spec:
             - name: kafka-ui-yaml-conf-configmap
               mountPath: /kafka-ui/
             {{- end }}
+            {{- if .Values.yamlApplicationConfigSecret}}
+            - name: kafka-ui-yaml-conf-secret
+              mountPath: /kafka-ui/
+            {{- end }}
           {{- end }}
-      {{- if or .Values.yamlApplicationConfig .Values.volumes .Values.yamlApplicationConfigConfigMap}}
+      {{- if or .Values.yamlApplicationConfig .Values.volumes .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
       volumes:
         {{- with .Values.volumes }}
           {{- toYaml . | nindent 8 }}
@@ -135,6 +141,11 @@ spec:
         - name: kafka-ui-yaml-conf-configmap
           configMap: 
             name: {{ .Values.yamlApplicationConfigConfigMap.name }}
+        {{- end }}
+        {{- if .Values.yamlApplicationConfigSecret}}
+        - name: kafka-ui-yaml-conf-secret
+          secret:
+            secretName: {{ .Values.yamlApplicationConfigSecret.name }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -40,6 +40,11 @@ yamlApplicationConfigConfigMap:
   {}
   # keyName: config.yml
   # name: configMapName
+yamlApplicationConfigSecret:
+  {}
+  # keyName: config.yml
+  # name: secretName
+
 existingSecret: ""
 envs:
   secret: {}


### PR DESCRIPTION
Resolves https://github.com/kafbat/helm-charts/issues/9
Implementation is similar to `yamlApplicationConfigConfigMap` approach.
Maybe in the future it will make sense to review the approach a little bit, because right now it's possible to pass simultaneously `yamlApplicationConfig`, `yamlApplicationConfigConfigMap` and `yamlApplicationConfigSecret`, they all will be handled correctly, but only one of them will be actually used as a config file for the application (due to if/else [here](https://github.com/kafbat/helm-charts/blob/main/charts/kafka-ui/templates/deployment.yaml#L57-L62)). IMHO this might be not really obvious. 

I suspect I should also upgrade the documentation [here](https://github.com/kafbat/ui-docs/blob/main/configuration/helm-charts/configuration/README.md)?


Tested locally, worked without any issues:
```
helm ls
NAME    	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART         	APP VERSION
kafka-ui	kafka-ui 	2       	2024-04-19 14:45:11.72722 +0300 EEST	deployed	kafka-ui-1.3.0	v1.0.0

helm get values kafka-ui
USER-SUPPLIED VALUES:
resources:
  limits:
    memory: 512Mi
  requests:
    cpu: 200m
    memory: 512Mi
yamlApplicationConfigSecret:
  keyName: config.yaml
  name: kafka-ui-config
```
Application is also working and reachable.