### PR TITLE
Set environment variables from secretRef/configMap

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -64,6 +64,20 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
+          {{- range $key, $value := .Values.envs.secretMappings }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "Missing required value envs.secretMappings.[].name" $value.name }}
+                  key: {{ required "Missing required value envs.secretMappings.[].keyName"  $value.keyName }}
+          {{- end }}
+          {{- range $key, $value := .Values.envs.configMappings }}
+            - name: {{ $key }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ required "Missing required value envs.configMappings.[].name" $value.name }}
+                  key: {{ required "Missing required value envs.configMappings.[].keyName"  $value.keyName }}
+          {{- end }}
           envFrom:
             {{- if .Values.existingConfigMap }}
             - configMapRef:

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -49,6 +49,14 @@ existingSecret: ""
 envs:
   secret: {}
   config: {}
+  secretMappings: {}
+    #ENV_NAME:
+    #  name: kubernetes-secret-name
+    #  keyName: kubernetes-secret-key
+  configMappings: {}
+    #ENV_NAME:
+    #  name: kubernetes-configmap-name
+    #  keyName: kubernetes-configmap-key
 
 networkPolicy:
   enabled: false


### PR DESCRIPTION
Current situation:
- existing secrets or configMaps can be added via .Values.existingSecret or .Values.existingConfigMap
- only one of each is possible at a time
- it is not possible to set a custom environment variable where the value is set

With the change it is possible to set a named environment variable to a specific key in a specific secret or config map.

Use case:  
When running Kafka with Strimzi, each KafkaUser entity gets its own secret with the password and sasl.jaas.config. With the new feature it's possible to directly access this secret and use it for Kafka UI.
```yaml
  secretMappings:
    KAFKA_CLUSTERS_0_PROPERTIES_SASL_JAAS_CONFIG:
      secretName: mySuperUser
      secretKey: sasl.jaas.config
```
There may be a lot more use cases for this feature. That's why I added the same for configMapKeyRef.

_Side note_:  
I had to set all other `kafka.clusters.*` values as envs.config instead of using yamlApplicationConfig, but not `auth.*` or `management.*`. It looks like the application does not deep-merge values from config file and YAML configuration. I didn't find this in the docs.