### PR TITLE
Add support for sidecars to the kafka-UI pod

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -127,6 +127,9 @@ spec:
               mountPath: /kafka-ui/
             {{- end }}
           {{- end }}
+        {{- with .Values.extraContainers }}
+        {{ tpl . $ | nindent 8 }}
+        {{- end }}
       {{- if or .Values.yamlApplicationConfig .Values.volumes .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
       volumes:
         {{- with .Values.volumes }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -168,3 +168,21 @@ volumeMounts: {}
 volumes: {}
 
 hostAliases: {}
+
+## Specify additional containers in extraContainers.
+## For example, to add an authentication proxy to a kafka-ui pod.
+extraContainers: |
+# - name: proxy
+#   image: quay.io/gambol99/keycloak-proxy:latest
+#   args:
+#   - -provider=github
+#   - -client-id=
+#   - -client-secret=
+#   - -github-org=<ORG_NAME>
+#   - -email-domain=*
+#   - -cookie-secret=
+#   - -http-address=http://0.0.0.0:4181
+#   - -upstream-url=http://127.0.0.1:3000
+#   ports:
+#     - name: proxy-web
+#       containerPort: 4181


### PR DESCRIPTION
Hi Guys,

I added `extraContainers` to be able to add sidecars to the Kafka-UI pod. In our case, this would be for adding a authentication proxy to that we can handle access to the Kafka-UI via our IAM solution. Might be handy for others, too.

Let me know what you're thinking.

thanks,
Marius