### PR TITLE
Use tpl on network policies custom rules to allow for dynamic values

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.4.8
+version: 1.4.9
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/networkpolicy-egress.yaml
+++ b/charts/kafka-ui/templates/networkpolicy-egress.yaml
@@ -14,6 +14,6 @@ spec:
     - Egress
   egress:
     {{- if .Values.networkPolicy.egressRules.customRules }}
-    {{- toYaml .Values.networkPolicy.egressRules.customRules | nindent 4 }}
+    {{- tpl (toYaml .Values.networkPolicy.egressRules.customRules) $ | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/kafka-ui/templates/networkpolicy-ingress.yaml
+++ b/charts/kafka-ui/templates/networkpolicy-ingress.yaml
@@ -14,6 +14,6 @@ spec:
     - Ingress
   ingress:
     {{- if .Values.networkPolicy.ingressRules.customRules }}
-    {{- toYaml .Values.networkPolicy.ingressRules.customRules | nindent 4 }}
+    {{- tpl (toYaml .Values.networkPolicy.ingressRules.customRules) $ | nindent 4 }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
For large scenarios, sometimes we need to reference a namespace or a label containing some dynamic value.

With this change, we'll be able to use any variable in the custom rules.

```
customRules:
  - to:
    - namespaceSelector:
      matchLabels:
        kubernetes.io/metadata.name: data-stream-{{ .Values.dynamic.value }}
```
