### PR TITLE
Make envFrom conditional to fix validation error

### DIFF
--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec:
                   name: {{ required "Missing required value envs.configMappings.[].name" $value.name }}
                   key: {{ required "Missing required value envs.configMappings.[].keyName"  $value.keyName }}
           {{- end }}
+          {{- if or .Values.existingConfigMap .Values.envs.config .Values.existingSecret .Values.envs.secret }}
           envFrom:
             {{- if .Values.existingConfigMap }}
             - configMapRef:
@@ -94,7 +95,8 @@ spec:
             {{- if .Values.envs.secret}}
             - secretRef:
                 name: {{ include "kafka-ui.fullname" . }}
-            {{- end}}    
+            {{- end}}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
We are using kubeconform for validating our Helm chart manifests. This validation fails on an empty envFrom array:
```
/spec/template/spec/containers/0/envFrom' does not validate with https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.3/deployment.json#/properties/spec/$ref/properties/template/$ref/properties/spec/$ref/properties/containers/items/$ref/properties/envFrom/type: expected array, but got null
```
This PR makes the envFrom conditional, which ensures that envFrom is not null and the deployment manifest is valid according to the Kubernetes schema.