### PR TITLE
Fix missing envs key

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.4.5
+version: 1.4.6
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.4.6
+version: 1.4.8
 appVersion: v1.0.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -51,7 +51,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "kafka-ui.imageName" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.env  .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
+          {{- if or .Values.env
+              .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret
+              (.Values.envs).secretMappings (.Values.envs).configMappings
+          }}
           env:
             {{- with .Values.env }}
               {{- toYaml . | nindent 12 }}
@@ -66,20 +69,20 @@ spec:
               value: /kafka-ui/{{ .Values.yamlApplicationConfigSecret.keyName | default "config.yml" }}
               {{- end }}
             {{- end }}
-          {{- end }}
-          {{- range $key, $value := .Values.envs.secretMappings }}
+            {{- range $key, $value := .Values.envs.secretMappings }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
                   name: {{ required "Missing required value envs.secretMappings.[].name" $value.name }}
                   key: {{ required "Missing required value envs.secretMappings.[].keyName"  $value.keyName }}
-          {{- end }}
-          {{- range $key, $value := .Values.envs.configMappings }}
+            {{- end }}
+            {{- range $key, $value := .Values.envs.configMappings }}
             - name: {{ $key }}
               valueFrom:
                 configMapKeyRef:
                   name: {{ required "Missing required value envs.configMappings.[].name" $value.name }}
                   key: {{ required "Missing required value envs.configMappings.[].keyName"  $value.keyName }}
+            {{- end }}
           {{- end }}
           {{- if or .Values.existingConfigMap .Values.envs.config .Values.existingSecret .Values.envs.secret }}
           envFrom:


### PR DESCRIPTION
See issue https://github.com/kafbat/helm-charts/issues/25

Problem:
When .Values.envs.configMappings or .Values.envs.secretMappings is set but none of .Values.envs, .Values. yamlApplicationConfigConfigMap or .Values.yamlApplicationConfigSecret, the valueFrom sections of configMappings/secretMappings get rendered without the heading "envs" key.

Solution:
Add .Values.envs.configMappings and .Values.secretMappings to the condtional and extend the if block