### PR TITLE
add PDB and topologySpreadConstraints for multi replica deployments

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- end }}  
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -192,3 +192,15 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.topologySpreadConstraints.maxSkew }}
+          minDomains: {{ .Values.topologySpreadConstraints.minDomains }}
+          topologyKey: {{ .Values.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfiable: {{ .Values.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "kafka-ui.selectorLabels" . | nindent 14 }}
+          matchLabelKeys:
+              - pod-template-hash              
+      {{- end }}    

--- a/charts/kafka-ui/templates/pod-disruption-budget.yaml
+++ b/charts/kafka-ui/templates/pod-disruption-budget.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kafka-ui.fullname" . }}
+spec:
+  {{- toYaml .Values.podDisruptionBudget.spec | nindent 2 }}
+  selector:
+    matchLabels:
+      {{- include "kafka-ui.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -69,12 +69,14 @@ envs:
   ## @param envs.config Set of the environment variables to pass to Kafbat-UI
   config: {}
   ## @param envs.secretMappings The mapping of existing secret to env variable.
-  secretMappings: {}
+  secretMappings:
+    {}
     #ENV_NAME:
     #  name: kubernetes-secret-name
     #  keyName: kubernetes-secret-key
   ## @param envs.configMappings  The mapping of configmap and keyName to get env variable.
-  configMappings: {}
+  configMappings:
+    {}
     #ENV_NAME:
     #  name: kubernetes-configmap-name
     #  keyName: kubernetes-configmap-key
@@ -218,7 +220,6 @@ ingress:
   ##
   path: "/"
 
-
   ## @param ingress.pathType Ingress path type
   pathType: "Prefix"
 
@@ -269,3 +270,17 @@ affinity: {}
 
 ## @param revisionHistoryLimit [nullable] Specify how many old ReplicaSets for this Deployment you want to retain
 revisionHistoryLimit: null
+
+# Pod Disruption Budget: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  spec:
+    minAvailable: "50%"
+
+# Topology Spread Constraints: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints:
+  enabled: false
+  maxSkew: 1
+  topologyKey: topology.kubernetes.io/zone
+  minDomains: 2
+  whenUnsatisfiable: DoNotSchedule # Must be DoNotSchedule if minDomains > 1


### PR DESCRIPTION
Adds optional `PodDisruptionBudget` and `topologySpreadConstraints`. Both are disabled by default and can be enabled and configured when using deployments with more than `1` replica

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable Pod Disruption Budget to control pod availability during disruptions.
  * Add configurable Topology Spread Constraints to improve pod distribution across zones.

* **Chores**
  * Update chart defaults for environment mappings and add new scheduling/disruption value entries.
  * Bump chart version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->