### PR TITLE
feat(helm): Support dnsConfig in deployment

### DIFF
--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
       serviceAccountName: {{ include "kafka-ui.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -105,6 +105,23 @@ volumes: {}
 ##
 hostAliases: {}
 
+## @section DNS Configuration for Pods
+## @param dnsConfig Specifies the DNS parameters of a pod
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-container/#pod-dns-config
+dnsConfig: {}
+  ## @param dnsConfig.nameservers [list] A list of IP addresses that will be used as DNS servers for the Pod.
+  # nameservers:
+  #   - 1.2.3.4
+  ## @param dnsConfig.searches [list] A list of DNS search domains for hostname lookup in the Pod.
+  # searches:
+  #   - ns1.svc.cluster-domain.example
+  #   - my.dns.search.suffix
+  ## @param dnsConfig.options [list] A list of objects where each object may have a `name` property (required) and a `value` property (optional). Options are used to configure the behavior of the DNS resolver.
+  # options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
+
 ## @param extraContainers Specify additional containers in extraContainers.
 ## For example, to add an authentication proxy to a kafka-ui pod.
 extraContainers: |


### PR DESCRIPTION
## Background

- By supporting the customization of [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config), cluster administrators can adjust settings to fit their cluster DNS environment, allowing them to handle network issues like CoreDNS CPU overload caused by kafka-ui pod more flexibly.

## Changes

- Support `spec.dnsConfig` in deployment template

## Reference

- Similar to PR https://github.com/kyverno/kyverno/pull/12608