### PR TITLE
Set values to match pss-restricted by default

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -184,17 +184,19 @@ probes:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext [object] The security settings that you specify for a Pod apply to all Containers in the Pod
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+   fsGroup: 2000
 ## @param securityContext [object] The security settings that you specify for a Kafka-UI container
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false # https://github.com/kafbat/kafka-ui/issues/78
+  runAsGroup: 2000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 ## @section Traffic Exposure Parameters
 ## Kafka-UI service parameters


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

This denotes the current security best practices.

Replaces: https://github.com/kafbat/helm-charts/pull/13 as my branch got screwed up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Kafka-UI Helm chart to version 1.6.2.
  * Hardened container security: stricter isolation, non-root execution, dropped capabilities, reduced privilege escalation, and enforced seccomp/profile and filesystem group settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->