### PR TITLE
Template some config settings

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.3
+version: 1.6.4
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.4
+version: 1.6.5
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             {{- end }}
             {{- if .Values.existingSecret }}
             - secretRef:
-                name: {{ tpl .Values.existingSecret . }}
+                name: {{ tpl .Values.existingSecret . | quote }}
             {{- end }}
             {{- if .Values.envs.secret}}
             - secretRef:
@@ -173,12 +173,12 @@ spec:
         {{- if .Values.yamlApplicationConfigConfigMap}}
         - name: kafka-ui-yaml-conf-configmap
           configMap:
-            name: {{ tpl .Values.yamlApplicationConfigConfigMap.name . }}
+            name: {{ tpl .Values.yamlApplicationConfigConfigMap.name . | quote }}
         {{- end }}
         {{- if .Values.yamlApplicationConfigSecret}}
         - name: kafka-ui-yaml-conf-secret
           secret:
-            secretName: {{ tpl .Values.yamlApplicationConfigSecret.name . }}
+            secretName: {{ tpl .Values.yamlApplicationConfigSecret.name . | quote }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -64,9 +64,9 @@ spec:
               {{- if .Values.yamlApplicationConfig }}
               value: /kafka-ui/config.yml
               {{- else if .Values.yamlApplicationConfigConfigMap }}
-              value: /kafka-ui/{{ tpl .Values.yamlApplicationConfigConfigMap.keyName . | default "config.yml" }}
+              value: /kafka-ui/{{ tpl (default "config.yml" .Values.yamlApplicationConfigConfigMap.keyName) . }}
               {{- else if .Values.yamlApplicationConfigSecret }}
-              value: /kafka-ui/{{ tpl .Values.yamlApplicationConfigSecret.keyName . | default "config.yml" }}
+              value: /kafka-ui/{{ tpl (default "config.yml" .Values.yamlApplicationConfigSecret.keyName) . }}
               {{- end }}
             {{- end }}
             {{- with .Values.env }}
@@ -142,7 +142,7 @@ spec:
           {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
           volumeMounts:
             {{- with .Values.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
             {{- if .Values.yamlApplicationConfig }}
             - name: kafka-ui-yaml-conf
@@ -162,8 +162,8 @@ spec:
         {{- end }}
       {{- if or .Values.yamlApplicationConfig .Values.volumes .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
       volumes:
-        {{- with tpl .Values.volumes . }}
-          {{- toYaml . | nindent 8 }}
+        {{- with .Values.volumes }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         {{- if .Values.yamlApplicationConfig }}
         - name: kafka-ui-yaml-conf

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -64,34 +64,34 @@ spec:
               {{- if .Values.yamlApplicationConfig }}
               value: /kafka-ui/config.yml
               {{- else if .Values.yamlApplicationConfigConfigMap }}
-              value: /kafka-ui/{{ .Values.yamlApplicationConfigConfigMap.keyName | default "config.yml" }}
+              value: /kafka-ui/{{ tpl .Values.yamlApplicationConfigConfigMap.keyName . | default "config.yml" }}
               {{- else if .Values.yamlApplicationConfigSecret }}
-              value: /kafka-ui/{{ .Values.yamlApplicationConfigSecret.keyName | default "config.yml" }}
+              value: /kafka-ui/{{ tpl .Values.yamlApplicationConfigSecret.keyName . | default "config.yml" }}
               {{- end }}
             {{- end }}
             {{- with .Values.env }}
-              {{- toYaml . | nindent 12 }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.envs.secretMappings }}
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "Missing required value envs.secretMappings.[].name" $value.name }}
-                  key: {{ required "Missing required value envs.secretMappings.[].keyName"  $value.keyName }}
+                  name: {{ tpl (required "Missing required value envs.secretMappings.[].name" $value.name) $ | quote }}
+                  key: {{ tpl (required "Missing required value envs.secretMappings.[].keyName" $value.keyName) $ | quote }}
             {{- end }}
             {{- range $key, $value := .Values.envs.configMappings }}
             - name: {{ $key }}
               valueFrom:
                 configMapKeyRef:
-                  name: {{ required "Missing required value envs.configMappings.[].name" $value.name }}
-                  key: {{ required "Missing required value envs.configMappings.[].keyName"  $value.keyName }}
+                  name: {{ tpl (required "Missing required value envs.configMappings.[].name" $value.name) $ | quote }}
+                  key: {{ tpl (required "Missing required value envs.configMappings.[].keyName"  $value.keyName) $ | quote }}
             {{- end }}
           {{- end }}
           {{- if or .Values.existingConfigMap .Values.envs.config .Values.existingSecret .Values.envs.secret }}
           envFrom:
             {{- if .Values.existingConfigMap }}
             - configMapRef:
-                name: {{ .Values.existingConfigMap }}
+                name: {{ tpl .Values.existingConfigMap . | quote }}
             {{- end }}
             {{- if .Values.envs.config }}
             - configMapRef:
@@ -99,7 +99,7 @@ spec:
             {{- end }}
             {{- if .Values.existingSecret }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ tpl .Values.existingSecret . }}
             {{- end }}
             {{- if .Values.envs.secret}}
             - secretRef:
@@ -141,7 +141,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
           volumeMounts:
-            {{- with .Values.volumeMounts }} 
+            {{- with .Values.volumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- if .Values.yamlApplicationConfig }}
@@ -162,23 +162,23 @@ spec:
         {{- end }}
       {{- if or .Values.yamlApplicationConfig .Values.volumes .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
       volumes:
-        {{- with .Values.volumes }}
+        {{- with tpl .Values.volumes . }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.yamlApplicationConfig }}
         - name: kafka-ui-yaml-conf
-          configMap: 
+          configMap:
             name: {{ include "kafka-ui.fullname" . }}-fromvalues
         {{- end }}
         {{- if .Values.yamlApplicationConfigConfigMap}}
         - name: kafka-ui-yaml-conf-configmap
-          configMap: 
-            name: {{ .Values.yamlApplicationConfigConfigMap.name }}
+          configMap:
+            name: {{ tpl .Values.yamlApplicationConfigConfigMap.name . }}
         {{- end }}
         {{- if .Values.yamlApplicationConfigSecret}}
         - name: kafka-ui-yaml-conf-secret
           secret:
-            secretName: {{ .Values.yamlApplicationConfigSecret.name }}
+            secretName: {{ tpl .Values.yamlApplicationConfigSecret.name . }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -173,12 +173,12 @@ spec:
         {{- if .Values.yamlApplicationConfigConfigMap}}
         - name: kafka-ui-yaml-conf-configmap
           configMap:
-            name: {{ tpl .Values.yamlApplicationConfigConfigMap.name . | quote }}
+            name: {{ tpl (required "Missing required value yamlApplicationConfigConfigMap/name" .Values.yamlApplicationConfigConfigMap.name) . | quote }}
         {{- end }}
         {{- if .Values.yamlApplicationConfigSecret}}
         - name: kafka-ui-yaml-conf-secret
           secret:
-            secretName: {{ tpl .Values.yamlApplicationConfigSecret.name . | quote }}
+            secretName: {{ tpl (required "Missing required value yamlApplicationConfigSecret/name" .Values.yamlApplicationConfigSecret.name) . | quote }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-        - {{ tpl .Values.ingress.host . }}
+        - {{ tpl .Values.ingress.host . | quote }}
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   {{- if .Values.ingress.ingressClassName }}
@@ -70,7 +70,7 @@ spec:
                   number: {{ .servicePort }}
           {{- end }}
 {{- if tpl .Values.ingress.host . }}
-      host: {{tpl .Values.ingress.host . }}
+      host: {{ tpl .Values.ingress.host . | quote }}
 {{- end }}
 {{- else -}}
           {{- range .Values.ingress.precedingPaths }}
@@ -92,7 +92,7 @@ spec:
               servicePort: {{ .servicePort }}
           {{- end }}
 {{- if tpl .Values.ingress.host . }}
-      host: {{ tpl .Values.ingress.host . }}
+      host: {{ tpl .Values.ingress.host . | quote }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Template the config settings that can be used to configure the cluster that kafka-ui talks to.

Happened to clean up a bit of trailing whitespace.

Partially addresses #52. (the parts that I need and a few similar settings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm template rendering so environment variables, config maps/secrets, ingress hosts, and volume/mount settings are correctly evaluated, quoted, and substituted during deployment to prevent misconfiguration.

* **Chores**
  * Bumped Helm chart version to 1.6.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kafbat/helm-charts/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->