### PR TITLE
chore: allow SPRING_CONFIG_ADDITIONAL-LOCATION to be overwritten by env

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -59,9 +59,6 @@ spec:
               (.Values.envs).secretMappings (.Values.envs).configMappings
           }}
           env:
-            {{- with .Values.env }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
             {{- if or .Values.yamlApplicationConfig .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}
             - name: SPRING_CONFIG_ADDITIONAL-LOCATION
               {{- if .Values.yamlApplicationConfig }}
@@ -71,6 +68,9 @@ spec:
               {{- else if .Values.yamlApplicationConfigSecret }}
               value: /kafka-ui/{{ .Values.yamlApplicationConfigSecret.keyName | default "config.yml" }}
               {{- end }}
+            {{- end }}
+            {{- with .Values.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.envs.secretMappings }}
             - name: {{ $key }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted environment configuration ordering in deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->