### PR TITLE
Create new HTTPRoute template & update values file

### DIFF
--- a/charts/kafka-ui/templates/http-route.yaml
+++ b/charts/kafka-ui/templates/http-route.yaml
@@ -1,0 +1,77 @@
+{{- range $routeIdx, $route := .Values.httpRoutes }}
+{{- if $route.enabled }}
+{{- if or (not $route.gatewayParentRefs) (lt (len $route.gatewayParentRefs) 1) }}
+{{- fail (printf "httpRoute[%d].gatewayParentRefs must be defined and contain at least one gateway reference." $routeIdx) }}
+{{- end -}}
+
+{{- if or (not $route.matches) (lt (len $route.matches) 1) }}
+{{- fail (printf "httpRoute[%d].matches must be defined and contain at least one match element." $routeIdx) }}
+{{- end -}}
+
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ tpl ($route.nameOverride | default (printf "%s-%s" $.Chart.Name (first $route.gatewayParentRefs).name)) $ }}-httproute
+  labels:
+    {{- include "kafka-ui.labels" $ | nindent 4 }}
+    {{- if $route.labels }}
+    {{- tpl (toYaml $route.labels) $ | nindent 4 }}
+    {{- end }}
+  {{- if $route.annotations }}
+  annotations:
+    {{- tpl (toYaml $route.annotations) $ | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- range $idx, $parentRef := $route.gatewayParentRefs }}
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ tpl (required (printf "httpRoutes[%d].gatewayParentRefs[%d].name is required." $routeIdx $idx) $parentRef.name) $ }}
+    {{- if $parentRef.namespace }}
+    namespace: {{ tpl ($parentRef.namespace) $ }}
+    {{- end }}
+    {{- if $parentRef.sectionName }}
+    sectionName: {{ tpl ($parentRef.sectionName) $ }}
+    {{- end }}
+  {{- end }}
+  hostnames:
+  {{- tpl (toYaml $route.hostnames) $ | nindent 2 }}
+  rules:
+  - matches:
+    {{- tpl (toYaml $route.matches) $ | nindent 4 }}
+    {{- if $route.shouldRouteToService }}
+    backendRefs:
+    - group: ''
+      kind: Service
+      name: {{ include "kafka-ui.fullname" $ }}
+      port: {{ tpl ($.Values.service.port | default "80" | quote) $ }}
+      weight: 1
+    {{- end }}
+    {{- if $route.filters }}
+    filters:
+    {{- if $route.shouldStripPath }}
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: "/"
+    {{- end }}
+    {{- tpl (toYaml $route.filters) $ | nindent 4 }}
+    {{- else if $route.shouldStripPath }}
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          type: ReplacePrefixMatch
+          replacePrefixMatch: "/"
+    {{- end }}
+    {{- if $route.timeouts }}
+    timeouts:
+    {{- tpl (toYaml $route.timeouts) $ | nindent 4 }}
+    {{- end }}
+{{- /* Add a document separator if there is another item coming */ -}}
+{{- if lt (add1 $routeIdx) (len $.Values.httpRoutes) -}}
+---
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kafka-ui/templates/http-route.yaml
+++ b/charts/kafka-ui/templates/http-route.yaml
@@ -44,7 +44,7 @@ spec:
     - group: ''
       kind: Service
       name: {{ include "kafka-ui.fullname" $ }}
-      port: {{ tpl ($.Values.service.port | default "80" | quote) $ }}
+	  port: {{ (tpl (default "80" ($.Values.service.port)) $) | int }}
       weight: 1
     {{- end }}
     {{- if $route.filters }}

--- a/charts/kafka-ui/templates/http-route.yaml
+++ b/charts/kafka-ui/templates/http-route.yaml
@@ -34,8 +34,10 @@ spec:
     sectionName: {{ tpl ($parentRef.sectionName) $ }}
     {{- end }}
   {{- end }}
+  {{- with $route.hostnames }}
   hostnames:
-  {{- tpl (toYaml $route.hostnames) $ | nindent 2 }}
+  {{- tpl (toYaml .) $ | nindent 2 }}
+  {{- end }}
   rules:
   - matches:
     {{- tpl (toYaml $route.matches) $ | nindent 4 }}
@@ -44,7 +46,7 @@ spec:
     - group: ''
       kind: Service
       name: {{ include "kafka-ui.fullname" $ }}
-	  port: {{ (tpl (default "80" ($.Values.service.port)) $) | int }}
+      port: {{ (tpl (default "80" (toString $.Values.service.port)) $) | int }}
       weight: 1
     {{- end }}
     {{- if $route.filters }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -254,7 +254,47 @@ ingress:
 
   ## @param ingress.succeedingPaths [array] Http paths to add to the Ingress after the default path
   succeedingPaths: []
-## @param resources [object] Set Kafka-UI pod requests and limits for different resources like CPU or memory (essential for production workloads)
+
+## Kafka-UI HTTPRoute configuration
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+##
+## @param httpRoutes [array] HTTPRoute resources to create.
+httpRoutes:
+## @param httpRoutes.enabled [string] Enable this HTTPRoute
+- enabled: false
+  ## @param httpRoutes.hostnames [array] Hostnames to expose this HTTPRoute under
+  hostnames:
+  - "example.com"
+  ## @param httpRoutes.annotations [object] Additional annotations for the HTTPRoute resource.
+  annotations: {}
+  ## @param httpRoutes.labels [object] Labels for the HTTPRoute
+  labels: {}
+  ## @param httpRoutes.nameOverride [string] The name to give this HTTPRoute resource.
+  nameOverride: ""
+  ## @param httpRoutes.gatewayParentRefs [array] Which gateway to bind this HTTPRoute to
+  gatewayParentRefs:
+  ## @param httpRoutes.gatewayParentRefs.name [string] The name of the gateway to bind this HTTPRoute to.
+  - name: "gateway-example"
+    ## @param httpRoutes.gatewayParentRefs.namespace [string] The namespace that the gateway is defined under.
+    namespace: "gateway-example"
+    ## @param httpRoutes.gatewayParentRefs.sectionName [string] The section name of the listener to bind to on the Gateway.
+    sectionName: "http-listener"
+  ## @param httpRoutes.shouldStripPath [string] Whether to strip the path before sending the request to the service.
+  shouldStripPath: true
+  ## @param httpRoutes.shouldRouteToService [string] Whether this HTTPRoute should route to the backend service.
+  shouldRouteToService: true
+  ## @param httpRoutes.matches [array] HTTPRoute match rules, ref: https://gateway-api.sigs.k8s.io/reference/spec/#httproutematch.
+  matches:
+  ## @param httpRoutes.matches.path [object] Match the route based on this path structure.
+  - path:
+      ## @param httpRoutes.matches.path.type [string] One of Exact, PathPrefix or RegularExpression.
+      type: PathPrefix
+      ## @param httpRoutes.matches.path.value [string] The path to match on after the host.
+      value: "/kafka-ui"
+  ## @param httpRoutes.filters [array] HTTPRoute filters, ref: https://gateway-api.sigs.k8s.io/reference/spec/#httproutefilter.
+  filters: []
+  ## @param httpRoutes.timeouts [object] HTTPRoute timeouts, ref: https://gateway-api.sigs.k8s.io/reference/spec/#httproutetimeouts.
+  timeouts: {}
 
 ## @section Scheduling
 


### PR DESCRIPTION
Add support for deploying HTTPRoute resources, as well as Ingress. This allows teams making use of the Gateway API to expose kafka-ui via this chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm chart support for configuring Kubernetes Gateway API `HTTPRoute` resources.
  * Configure hostnames, gateway bindings, path matching, optional path rewriting, service routing, custom filters, and request timeouts.
  * Added options for route metadata, including annotations, labels, and custom names.
  * Service ports default to port 80 when not explicitly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->