### PR TITLE
Allow specifying ingress.tls.host if it is different from ingress.host

### DIFF
--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -81,6 +81,7 @@
 | `ingress.pathType`         | Ingress path type                                                                                                                | `Prefix`    |
 | `ingress.host`             | Default hostname for the ingress record                                                                                          | `""`        |
 | `ingress.tls.enabled`      | Enable TLS configuration for the host defined at `ingress.host` parameter                                                        | `false`     |
+| `ingress.tls.host`         | Optional host value for TLS certificate used by the ingress, value of `ingress.host` is used if not defined                      | `""`        |
 | `ingress.tls.secretName`   | The name of a pre-created Secret containing a TLS private key and certificate                                                    | `""`        |
 | `ingress.precedingPaths`   | HTTP paths to add to the Ingress before the default path                                                                         | `[]`        |
 | `ingress.succeedingPaths`  | Http paths to add to the Ingress after the default path                                                                          | `[]`        |

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.2
+version: 1.6.4
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/ingress.yaml
+++ b/charts/kafka-ui/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-        - {{ tpl .Values.ingress.host . }}
+        - "{{ tpl (.Values.ingress.tls.host | default .Values.ingress.host) . }}"
       secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   {{- if .Values.ingress.ingressClassName }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -246,6 +246,8 @@ ingress:
     # Enable TLS termination for the Ingress
     ## @param ingress.tls.enabled Enable TLS configuration for the host defined at `ingress.host` parameter
     enabled: false
+    ## @param ingress.tls.host Optional host value for TLS certificate used by the ingress, value of `ingress.host` is used if not defined
+    host: ""
     ## @param ingress.tls.secretName [string] The name of a pre-created Secret containing a TLS private key and certificate
     secretName: ""
 


### PR DESCRIPTION
This is needed when using wildcard certificates, for example this set of values:

```yaml
ingress:
  enabled: true
  host: kafbat-ui.example.com
  tls:
    enabled: true
    host: "*.example.com"
    secretName: tls-wildcard-example-com
```

will generate:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
spec:
  tls:
    - hosts:
        - "*.example.com"
      secretName: tls-wilcard-example-com
  ...etc...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional TLS host setting for Kafka-UI Helm charts. You can specify a separate hostname for TLS certificates distinct from the ingress host; if left empty it falls back to the existing ingress host. Applies only when TLS is enabled.
* **Chores**
  * Helm chart version bumped to 1.6.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kafbat/helm-charts/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->