### PR TITLE
feat: add startup probe support

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: v1.4.2
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -128,6 +128,15 @@ spec:
               scheme: HTTPS
               {{- end }}
             {{- toYaml .Values.probes.readiness | nindent 12 }}
+          startupProbe:
+            httpGet:
+              {{- $contextPath := .Values.envs.config.SERVER_SERVLET_CONTEXT_PATH | default "" | printf "%s/actuator/health" | urlParse }}
+              path: {{ get $contextPath "path" }}
+              port: http
+              {{- if .Values.probes.useHttpsScheme }}
+              scheme: HTTPS
+              {{- end }}
+            {{- toYaml .Values.probes.startup | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -179,6 +179,11 @@ probes:
     periodSeconds: 30
     ## @param probes.readiness.timeoutSeconds Timeout seconds for readiness probe
     timeoutSeconds: 10
+  startup:
+    ## @param probes.startup.failureThreshold Failure threshold for startup probe
+    failureThreshold: 5
+    ## @param probes.startup.periodSeconds Period seconds for startup probe
+    periodSeconds: 40
 
 ## @section Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -184,6 +184,8 @@ probes:
     failureThreshold: 5
     ## @param probes.startup.periodSeconds Period seconds for startup probe
     periodSeconds: 40
+    ## @param probes.startup.timeoutSeconds Timeout seconds for startup probe
+    timeoutSeconds: 10
 
 ## @section Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod


### PR DESCRIPTION
## Summary

- Adds `startupProbe` support to the kafka-ui Helm chart, following the same pattern as the existing `livenessProbe` and `readinessProbe`
- Adds `probes.startup` values block with sensible defaults (`failureThreshold: 5`, `periodSeconds: 40`) giving a 200s startup window
- Reuses the dynamic context path construction (`SERVER_SERVLET_CONTEXT_PATH`) and `probes.useHttpsScheme` flag already used by the other probes

## Test plan

- [ ] `helm template` renders `startupProbe` with correct path and port
- [ ] Custom `SERVER_SERVLET_CONTEXT_PATH` is reflected in the startup probe path
- [ ] `probes.useHttpsScheme: true` adds `scheme: HTTPS` to the startup probe
- [ ] `probes.startup.failureThreshold` and `probes.startup.periodSeconds` can be overridden via values
- [ ] `helm lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a startup probe to improve health monitoring during container startup, complementing existing readiness and liveness checks.
  * Introduced configurable startup probe parameters (failure threshold, period, timeout) so deployments can tune initialization waits.
  * Bumped the chart version to reflect these operational improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->