### PR TITLE
feat: extraManifests support

### DIFF
--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -12,6 +12,7 @@
 | `imagePullSecrets` | Docker registry secret names as an array   | `[]`  |
 | `nameOverride`     | String to partially override chart name    | `""`  |
 | `fullnameOverride` | String to fully override app name          | `""`  |
+| `extraManifests`   | Arbitrary Kubernetes manifests             | `[]`  |
 
 ### ServiceAccount configuration
 

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.4
+version: 1.7.0
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/extra-manifests.yaml
+++ b/charts/kafka-ui/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraManifests }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{ else }}
+{{ tpl (. | toYaml) $ }}
+{{- end }}
+{{ end }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -19,6 +19,8 @@ imagePullSecrets: []
 nameOverride: ""
 ## @param fullnameOverride String to fully override app name
 fullnameOverride: ""
+## @param extraManifests Arbitrary Kubernetes manifests
+extraManifests: []
 
 ## @section ServiceAccount configuration
 serviceAccount:
@@ -294,3 +296,4 @@ affinity: {}
 
 ## @param revisionHistoryLimit [nullable] Specify how many old ReplicaSets for this Deployment you want to retain
 revisionHistoryLimit: null
+


### PR DESCRIPTION
this allows to declare arbitrary kubernetes resources.

Fixes https://github.com/kafbat/helm-charts/issues/57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `extraManifests` parameter enabling users to deploy arbitrary Kubernetes resources through Helm chart configuration values. This provides flexible resource management without requiring direct template modifications.

* **Documentation**
  * Configuration documentation updated to include documentation for the new `extraManifests` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->