### PR TITLE
feat: Add HTTPRoute support for Gateway API

### DIFF
--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -84,6 +84,15 @@
 | `ingress.tls.secretName`   | The name of a pre-created Secret containing a TLS private key and certificate                                                    | `""`        |
 | `ingress.precedingPaths`   | HTTP paths to add to the Ingress before the default path                                                                         | `[]`        |
 | `ingress.succeedingPaths`  | Http paths to add to the Ingress after the default path                                                                          | `[]`        |
+| `httproute.enabled`        | Enable HTTPRoute (Gateway API) record generation for Kafka-UI                                                                    | `false`     |
+| `httproute.annotations`    | Additional annotations for the HTTPRoute resource                                                                                | `{}`        |
+| `httproute.labels`         | Labels for the HTTPRoute resource                                                                                                | `{}`        |
+| `httproute.parentRefs`     | Gateway references the HTTPRoute attaches to. At least one parentRef is required when httproute.enabled is true                  | `[]`        |
+| `httproute.hostnames`      | Hostnames to match for this HTTPRoute                                                                                            | `[]`        |
+| `httproute.pathType`       | Path matching type used by the default rule (PathPrefix, Exact, or RegularExpression)                                            | `PathPrefix`|
+| `httproute.path`           | Path used by the default rule when no custom rules are specified                                                                 | `/`         |
+| `httproute.scheme`         | Scheme for the HTTPRoute URL output (http or https)                                                                              | `http`      |
+| `httproute.rules`          | Advanced routing rules. If empty, a default rule matching httproute.path is generated. Any backendRefs in custom rules are ignored and the Kafka-UI service is always used. | `[]`        |
 | `resources`                | Set Kafka-UI pod requests and limits for different resources like CPU or memory (essential for production workloads)             | `{}`        |
 
 ### Scheduling

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.4
+version: 1.6.5
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/NOTES.txt
+++ b/charts/kafka-ui/templates/NOTES.txt
@@ -5,6 +5,10 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httproute.enabled }}
+{{- range $host := .Values.httproute.hostnames }}
+  {{ $.Values.httproute.scheme | default "http" }}://{{ $host }}{{ $.Values.httproute.path }}
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "kafka-ui.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/kafka-ui/templates/httproute.yaml
+++ b/charts/kafka-ui/templates/httproute.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "kafka-ui.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kafka-ui.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.httproute.parentRefs }}
+  {{- fail "httproute.parentRefs must contain at least one parentRef when httproute.enabled is true" }}
+  {{- end }}
+  parentRefs:
+    {{- toYaml .Values.httproute.parentRefs | nindent 4 }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.rules }}
+  {{- range .Values.httproute.rules }}
+    - {{- toYaml (omit . "backendRefs") | nindent 6 }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+  {{- end }}
+  {{- else }}
+    - matches:
+        - path:
+            type: {{ .Values.httproute.pathType | default "PathPrefix" }}
+            value: {{ .Values.httproute.path | default "/" }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $fullName }}
+          port: {{ $svcPort }}
+          weight: 1
+  {{- end }}
+{{- end }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -263,6 +263,54 @@ ingress:
 
   ## @param ingress.succeedingPaths [array] Http paths to add to the Ingress after the default path
   succeedingPaths: []
+
+## Kafka-UI HTTPRoute configuration (Gateway API)
+## Alternative to Ingress. Only enable this if you have the Gateway API CRDs
+## installed and a Gateway controller running in your cluster.
+## ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+##
+httproute:
+  ## @param httproute.enabled Enable HTTPRoute (Gateway API) record generation for Kafka-UI
+  enabled: false
+  ## @param httproute.annotations [object] Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param httproute.labels [object] Labels for the HTTPRoute resource
+  labels: {}
+
+  ## @param httproute.parentRefs [array] Gateway references the HTTPRoute attaches to. At least one parentRef is required when httproute.enabled is true
+  ## e.g:
+  ## parentRefs:
+  ##   - name: my-gateway
+  ##     namespace: gateway-system
+  ##     sectionName: http
+  ##
+  parentRefs: []
+
+  ## @param httproute.hostnames [array] Hostnames to match for this HTTPRoute (templated, so you can use Helm expressions). e.g: ["kafka-ui.example.com"]
+  hostnames: []
+
+  ## @param httproute.pathType Path matching type used by the default rule (PathPrefix, Exact, or RegularExpression)
+  pathType: PathPrefix
+  ## @param httproute.path Path used by the default rule when no custom rules are specified
+  path: /
+  ## @param httproute.scheme Scheme for the HTTPRoute URL output (http or https)
+  scheme: http
+
+  ## @param httproute.rules [array] Advanced routing rules. If empty, a default rule matching httproute.path is generated. Any backendRefs in custom rules are ignored and the Kafka-UI service is always used.
+  ## e.g:
+  ## rules:
+  ##   - matches:
+  ##       - path:
+  ##           type: PathPrefix
+  ##           value: /
+  ##     filters:
+  ##       - type: RequestHeaderModifier
+  ##         requestHeaderModifier:
+  ##           add:
+  ##             - name: X-Custom-Header
+  ##               value: custom-value
+  ##
+  rules: []
 ## @param resources [object] Set Kafka-UI pod requests and limits for different resources like CPU or memory (essential for production workloads)
 
 ## @section Scheduling


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Kubernetes Gateway API HTTPRoute support for traffic exposure, offering an alternative to Ingress.

* **Documentation**
  * Added HTTPRoute configuration docs (annotations, labels, parentRefs, hostnames, pathType/path, scheme, rules).
  * Installation notes updated to show HTTPRoute URLs when enabled.

* **Chores**
  * Chart version bumped to 1.6.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->