### PR TITLE
Add helm-unittest suites and CI for kafka-ui chart

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -7,6 +7,19 @@ on:
   paths:
    - "charts/**"
 jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Helm tool installer
+        uses: Azure/setup-helm@v3
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
+      - name: Run helm unit tests
+        run: helm unittest charts/kafka-ui
+
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -9,8 +9,10 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Helm tool installer
         uses: Azure/setup-helm@v3
 

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: Azure/setup-helm@v3
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
 
       - name: Run helm unit tests
         run: helm unittest charts/kafka-ui

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+# Pre-commit hooks for kafbat/helm-charts
+#
+# Install once:   pre-commit install
+# Run on demand:  pre-commit run --all-files
+#
+# These mirror what CI enforces (see .github/workflows/), so contributors
+# catch issues locally before pushing. During a normal `git commit` the hooks
+# only run against the files you staged, so they won't churn unrelated files.
+repos:
+  # Render the chart templates and assert on the output. Mirrors the
+  # `unit-test` job in .github/workflows/helm.yaml. Requires the plugin:
+  #   helm plugin install https://github.com/helm-unittest/helm-unittest
+  - repo: local
+    hooks:
+      - id: helm-unittest
+        name: helm unittest (kafka-ui)
+        entry: helm unittest charts/kafka-ui
+        language: system
+        files: '^charts/kafka-ui/(templates/.*|values\.yaml|Chart\.yaml|tests/.*\.yaml)$'
+        pass_filenames: false
+        verbose: true
+
+  # Keep CONFIGURATION.md in sync with the @param metadata in values.yaml.
+  # Mirrors the "Update README from values.yaml metadata" workflow, which
+  # otherwise auto-commits this on the PR.
+  - repo: local
+    hooks:
+      - id: readme-generator-for-helm
+        name: regenerate CONFIGURATION.md from values.yaml
+        entry: npx --yes @bitnami/readme-generator-for-helm --values charts/kafka-ui/values.yaml --readme charts/kafka-ui/CONFIGURATION.md
+        language: system
+        files: '^charts/kafka-ui/(values\.yaml|CONFIGURATION\.md)$'
+        pass_filenames: false
+
+  # General hygiene. These act only on staged files during a normal commit.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        # Helm templates rely on significant whitespace in places; leave them.
+        exclude: '^charts/.*/templates/.*$'
+      - id: end-of-file-fixer
+        exclude: '^charts/.*/templates/.*$'
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-yaml
+        # Helm templates are Go templates, not plain YAML — skip them.
+        exclude: '^charts/.*/templates/.*$'

--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -58,6 +58,9 @@
 | `probes.readiness.initialDelaySeconds` | Initial delay seconds for readiness probe                 | `10`    |
 | `probes.readiness.periodSeconds`       | Period seconds for readiness probe                        | `30`    |
 | `probes.readiness.timeoutSeconds`      | Timeout seconds for readiness probe                       | `10`    |
+| `probes.startup.failureThreshold`      | Failure threshold for startup probe                       | `5`     |
+| `probes.startup.periodSeconds`         | Period seconds for startup probe                          | `40`    |
+| `probes.startup.timeoutSeconds`        | Timeout seconds for startup probe                         | `10`    |
 
 ### Security Context
 

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.4
+version: 1.6.6
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/tests/README.md
+++ b/charts/kafka-ui/tests/README.md
@@ -1,0 +1,57 @@
+# Chart unit tests
+
+These suites use [`helm-unittest`](https://github.com/helm-unittest/helm-unittest)
+to render the chart's templates and assert on the resulting manifests. They run
+in milliseconds, need no Kubernetes cluster, and catch template regressions
+(missing fields, broken conditionals, failed `fail`/`required` guards) before a
+change is ever applied.
+
+## Running locally
+
+Install the plugin once:
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest
+```
+
+Then run the suites from the repository root:
+
+```bash
+helm unittest charts/kafka-ui
+```
+
+## Layout
+
+One suite per template, named `<template>_test.yaml`:
+
+| Suite | Template under test | Highlights |
+|-------|---------------------|------------|
+| `ingress_test.yaml`    | `ingress.yaml`    | API version selection, TLS, ingressClassName, templated host |
+| `service_test.yaml`    | `service.yaml`    | type/port, NodePort/LoadBalancer specifics, selector labels |
+| `deployment_test.yaml` | `deployment.yaml` | replicas vs. autoscaling, image reference, probes, env wiring |
+| `notes_test.yaml`      | `NOTES.txt`       | ClusterIP port-forward fallback |
+
+## Adding tests for a new feature
+
+When you add or change a template, add or update the matching `*_test.yaml`
+suite in the same PR. A good suite covers:
+
+1. **Does not render when disabled** — the feature's `enabled: false` path.
+2. **Renders correctly when enabled** — kind, apiVersion, name, namespace.
+3. **Each configurable knob** — one assertion per value that changes output.
+4. **Guards** — every `fail`/`required` is exercised with `failedTemplate`
+   so a misconfiguration is a red test, not a red CI render.
+
+### Notes for templates that `include` siblings
+
+`deployment.yaml` builds checksum annotations by `include`-ing `configmap.yaml`,
+`configmap_fromValues.yaml` and `secret.yaml`. Those templates must be listed
+under `templates:` so the includes resolve, and each test uses a
+`documentSelector` with `skipEmptyTemplates: true` to assert against the
+Deployment document while ignoring the (often empty) configmap/secret renders.
+
+### Notes for `NOTES.txt`
+
+`NOTES.txt` is plain text, not a manifest, so use the raw assertions
+(`matchRegexRaw`, `equalRaw`) which operate on the rendered text directly
+instead of a YAML `path`.

--- a/charts/kafka-ui/tests/deployment_test.yaml
+++ b/charts/kafka-ui/tests/deployment_test.yaml
@@ -1,0 +1,172 @@
+suite: Deployment
+
+# deployment.yaml computes checksum annotations by include-ing configmap.yaml,
+# configmap_fromValues.yaml and secret.yaml, so those templates must be loaded
+# for the suite to render. Those three emit no documents under most of these
+# cases, so each test selects the Deployment document and skips empty templates.
+templates:
+  - deployment.yaml
+  - configmap.yaml
+  - configmap_fromValues.yaml
+  - secret.yaml
+
+tests:
+  - it: renders a Deployment with the fullname and release namespace
+    release:
+      name: kafka-ui
+      namespace: kafka
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: metadata.name
+          value: kafka-ui
+      - equal:
+          path: metadata.namespace
+          value: kafka
+
+  - it: sets replicas from replicaCount when autoscaling is disabled
+    set:
+      replicaCount: 3
+      autoscaling:
+        enabled: false
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: omits replicas when autoscaling is enabled
+    set:
+      autoscaling:
+        enabled: true
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+
+  - it: builds the image reference from registry, repository and appVersion
+    chart:
+      appVersion: v1.5.0
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/kafbat/kafka-ui:v1.5.0
+
+  - it: allows the image tag to be overridden
+    set:
+      image:
+        tag: v1.4.0
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/kafbat/kafka-ui:v1.4.0
+
+  - it: honours a global imageRegistry override
+    set:
+      global:
+        imageRegistry: my-mirror.example.com
+      image:
+        tag: v1.5.0
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my-mirror.example.com/kafbat/kafka-ui:v1.5.0
+
+  - it: exposes the http container port 8080
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: wires the service account name
+    release:
+      name: kafka-ui
+    set:
+      serviceAccount:
+        create: true
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: kafka-ui
+
+  - it: defines liveness, readiness and startup probes
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - exists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: renders env entries supplied via env
+    set:
+      env:
+        - name: MY_VAR
+          value: my-value
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_VAR
+            value: my-value
+
+  - it: sets the config additional-location env when yamlApplicationConfig is set
+    set:
+      yamlApplicationConfig:
+        kafka:
+          clusters:
+            - name: local
+    documentSelector:
+      path: kind
+      value: Deployment
+      skipEmptyTemplates: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPRING_CONFIG_ADDITIONAL-LOCATION
+            value: /kafka-ui/config.yml

--- a/charts/kafka-ui/tests/ingress_test.yaml
+++ b/charts/kafka-ui/tests/ingress_test.yaml
@@ -1,0 +1,146 @@
+suite: Ingress
+
+templates:
+  - ingress.yaml
+
+tests:
+  - it: does not render when ingress is disabled
+    set:
+      ingress:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a networking.k8s.io/v1 Ingress on modern clusters
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      apiVersions:
+        - networking.k8s.io/v1
+    release:
+      name: kafka-ui
+      namespace: kafka
+    set:
+      ingress:
+        enabled: true
+        host: kafka-ui.local
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: kafka-ui
+      - equal:
+          path: metadata.namespace
+          value: kafka
+
+  - it: routes the default path to the kafka-ui service
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      apiVersions:
+        - networking.k8s.io/v1
+    release:
+      name: kafka-ui
+    set:
+      service:
+        port: 8080
+      ingress:
+        enabled: true
+        host: kafka-ui.local
+        path: /
+        pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: kafka-ui.local
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kafka-ui
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+
+  - it: sets the ingressClassName when provided
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      apiVersions:
+        - networking.k8s.io/v1
+    set:
+      ingress:
+        enabled: true
+        host: kafka-ui.local
+        ingressClassName: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: renders a TLS block when tls is enabled
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      apiVersions:
+        - networking.k8s.io/v1
+    set:
+      ingress:
+        enabled: true
+        host: kafka-ui.local
+        tls:
+          enabled: true
+          secretName: kafka-ui-tls
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: kafka-ui.local
+      - equal:
+          path: spec.tls[0].secretName
+          value: kafka-ui-tls
+
+  - it: templates the host value
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      apiVersions:
+        - networking.k8s.io/v1
+    release:
+      name: kafka-ui
+    set:
+      ingress:
+        enabled: true
+        host: "{{ .Release.Name }}.example.com"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: kafka-ui.example.com
+
+  - it: renders additional labels and annotations
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+      apiVersions:
+        - networking.k8s.io/v1
+    set:
+      ingress:
+        enabled: true
+        host: kafka-ui.local
+        labels:
+          custom-label: custom-value
+        annotations:
+          nginx.ingress.kubernetes.io/rewrite-target: /
+    asserts:
+      - equal:
+          path: metadata.labels.custom-label
+          value: custom-value
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: /

--- a/charts/kafka-ui/tests/notes_test.yaml
+++ b/charts/kafka-ui/tests/notes_test.yaml
@@ -1,0 +1,10 @@
+suite: NOTES
+
+templates:
+  - NOTES.txt
+
+tests:
+  - it: falls back to the ClusterIP port-forward note by default
+    asserts:
+      - matchRegexRaw:
+          pattern: "port-forward"

--- a/charts/kafka-ui/tests/service_test.yaml
+++ b/charts/kafka-ui/tests/service_test.yaml
@@ -1,0 +1,80 @@
+suite: Service
+
+templates:
+  - service.yaml
+
+tests:
+  - it: renders a Service with the fullname and release namespace
+    release:
+      name: kafka-ui
+      namespace: kafka
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: kafka-ui
+      - equal:
+          path: metadata.namespace
+          value: kafka
+
+  - it: defaults to ClusterIP on port 80 named http
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+
+  - it: honours a custom service type and port
+    set:
+      service:
+        type: LoadBalancer
+        port: 8080
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: sets nodePort only for NodePort services
+    set:
+      service:
+        type: NodePort
+        nodePort: 30080
+    asserts:
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30080
+
+  - it: sets loadBalancerIP only for LoadBalancer services
+    set:
+      service:
+        type: LoadBalancer
+        loadBalancerIP: 10.0.0.10
+    asserts:
+      - equal:
+          path: spec.loadBalancerIP
+          value: 10.0.0.10
+
+  - it: uses the selector labels for the pod selector
+    release:
+      name: kafka-ui
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: kafka-ui
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: kafka-ui


### PR DESCRIPTION
## What

Adds [`helm-unittest`](https://github.com/helm-unittest/helm-unittest) as a fast, cluster-free unit-testing harness for the `kafka-ui` chart, plus a CI job that runs it on every chart PR.

**25 tests across 4 suites**, covering the core templates:

| Suite | Template | Highlights |
|-------|----------|------------|
| `ingress_test.yaml`    | `ingress.yaml`    | API version selection, TLS, `ingressClassName`, templated host |
| `service_test.yaml`    | `service.yaml`    | type/port, NodePort/LoadBalancer specifics, selector labels |
| `deployment_test.yaml` | `deployment.yaml` | replicas vs. autoscaling, image reference, probes, env wiring |
| `notes_test.yaml`      | `NOTES.txt`       | ClusterIP port-forward fallback |

A `charts/kafka-ui/tests/README.md` documents how to run the suites locally and the pattern for adding tests when new templates/features land.

## Why

The suites render templates and assert on the resulting manifests in milliseconds, with no cluster required. They catch template regressions — missing fields, broken conditionals, failed `fail`/`required` guards — as red tests rather than red `helm template` renders in CI. The new `unit-test` job runs alongside the existing render/kubeconform job.

## Run locally

```bash
helm plugin install https://github.com/helm-unittest/helm-unittest
helm unittest charts/kafka-ui
```

## Notes for reviewers

- **Relationship to #67:** This is intentionally scoped to the templates already on `main`. A follow-up will add an `httproute_test.yaml` suite (including a `failedTemplate` case for the empty-`parentRefs` guard) once #67 merges — that test reproduces and pins the exact guard behavior introduced there.
- **Version:** bumped to `1.6.6` on the assumption #67 (`1.6.5`) merges first. Happy to rebase if the ordering changes.
- **Minor finding (not addressed here):** `NOTES.txt` renders the ingress URL from `.Values.ingress.hosts[].paths` (plural/list), but the chart's `values.yaml` uses `ingress.host` (singular). With standard values the ingress NOTES URL renders empty. Flagging for awareness; left out of this PR to avoid scope creep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Kafka UI Helm chart version to **1.6.6**
  * Added/updated pre-commit automation for Helm chart unit testing and regenerated chart configuration docs
* **Documentation**
  * Documented new **startup probe** parameters (`failureThreshold`, `periodSeconds`, `timeoutSeconds`)
  * Added guidance for running and extending the Helm unit test suites
* **Tests**
  * Added Helm unit tests for **Deployment**, **Ingress**, **Service**, and **NOTES** output behavior
  * Added a GitHub Actions job to run chart unit tests on pull requests affecting chart files in `charts/**` targeting `main`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update: pre-commit config

Also adds a `.pre-commit-config.yaml` so contributors can run the same checks CI enforces, before pushing:

- **helm-unittest** — runs the chart unit tests (matches the new `unit-test` job)
- **readme-generator-for-helm** — regenerates `CONFIGURATION.md` from `values.yaml` `@param` metadata (matches the existing *Update README from values.yaml metadata* workflow, which otherwise auto-commits it)
- **hygiene** — trailing-whitespace, end-of-file, merge-conflict, large-file and YAML checks (Helm templates excluded; hooks only act on staged files during a normal commit, so they won't churn unrelated files)

```bash
pre-commit install
```

While wiring up the readme-generator hook I noticed `CONFIGURATION.md` had drifted from `values.yaml` — the `probes.startup.*` parameters added in #64 were never regenerated. This PR brings it back in sync.
