### PR TITLE
Use `[]` instead of `{}` for array-typed default values in kafka-ui

### DIFF
--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -34,12 +34,12 @@
 | `envs.config`                    | Set of the environment variables to pass to Kafbat-UI                                                                                              | `{}`  |
 | `envs.secretMappings`            | The mapping of existing secret to env variable.                                                                                                    | `{}`  |
 | `envs.configMappings`            | The mapping of configmap and keyName to get env variable.                                                                                          | `{}`  |
-| `env`                            | Envs to be added to the Kafka-UI container                                                                                                         | `{}`  |
+| `env`                            | Envs to be added to the Kafka-UI container                                                                                                         | `[]`  |
 | `resources`                      | Set Kafka-UI container requests and limits for different resources like CPU or memory (essential for production workloads)                         | `{}`  |
-| `initContainers`                 | Add additional init containers to the Kafka-UI pods                                                                                                | `{}`  |
-| `volumeMounts`                   | Optionally specify additional volumeMounts for the kafka-UI container                                                                              | `{}`  |
-| `volumes`                        | Optionally specify additional volumes for the Kafka-UI pods                                                                                        | `{}`  |
-| `hostAliases`                    | Kafka-UI pods host aliases                                                                                                                         | `{}`  |
+| `initContainers`                 | Add additional init containers to the Kafka-UI pods                                                                                                | `[]`  |
+| `volumeMounts`                   | Optionally specify additional volumeMounts for the kafka-UI container                                                                              | `[]`  |
+| `volumes`                        | Optionally specify additional volumes for the Kafka-UI pods                                                                                        | `[]`  |
+| `hostAliases`                    | Kafka-UI pods host aliases                                                                                                                         | `[]`  |
 | `extraContainers`                | Specify additional containers in extraContainers.                                                                                                  | `""`  |
 
 ### Network Policies

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.4
+version: 1.6.5
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -79,7 +79,7 @@ envs:
     #  name: kubernetes-configmap-name
     #  keyName: kubernetes-configmap-key
 ## @param env [object] Envs to be added to the Kafka-UI container
-env: {}
+env: []
 
 ## @param resources Set Kafka-UI container requests and limits for different resources like CPU or memory (essential for production workloads)
 resources:
@@ -94,16 +94,16 @@ resources:
 ## @param initContainers Add additional init containers to the Kafka-UI pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 ## e.g:
-initContainers: {}
+initContainers: []
 
 ## @param volumeMounts [object] Optionally specify additional volumeMounts for the kafka-UI container
-volumeMounts: {}
+volumeMounts: []
 ## @param volumes [object] Optionally specify additional volumes for the Kafka-UI pods
-volumes: {}
+volumes: []
 ## @param hostAliases [object] Kafka-UI pods host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
-hostAliases: {}
+hostAliases: []
 
 ## @param extraContainers Specify additional containers in extraContainers.
 ## For example, to add an authentication proxy to a kafka-ui pod.


### PR DESCRIPTION
Fixes #69

## Problem

`charts/kafka-ui/values.yaml` defaults `volumes`, `volumeMounts`, `initContainers`,
`hostAliases` and `env` to `{}` (empty map), but `templates/deployment.yaml` renders
all of them as Kubernetes **list** fields:

```
{{- with .Values.volumeMounts }}
{{- toYaml . | nindent 12 }}
{{- end }}
```

When a consumer overrides any of these with a proper list (as the k8s API and the
template both expect), Helm's value coalescing logs a warning because it can't
reconcile a table (map) default with a non-table (list) override:

```
coalesce.go:298: warning: cannot overwrite table with non table for <path>.volumes (map[])
```

The override still resolves correctly in the final rendered manifest — this is
cosmetic, not a functional bug — but it's confusing for anyone who doesn't already
know the root cause.

## Fix

Change the five defaults from `{}` to `[]`. `toYaml` on an empty list renders
nothing under the `with` guard, same as `toYaml` on an empty map does today, so
default (unset) behavior is unchanged.

## Testing

- `helm lint charts/kafka-ui` — passes
- `helm template charts/kafka-ui` (default values) — output unchanged
- `helm template --set ingress.enabled=true charts/kafka-ui -f charts/kafka-ui/values.yaml` (mirrors the CI kubeconform step) — succeeds
- `helm template charts/kafka-ui -f <values overriding volumes/volumeMounts with a list>` — no more coalesce warning, output correct

Also bumped `Chart.yaml` version (1.6.4 → 1.6.5) per the version-bump check in
`helm.yaml`, and updated `CONFIGURATION.md` for the five changed defaults
(regenerated by hand — `@bitnami/readme-generator-for-helm` needs npm, not
available in my sandbox; happy to have CI regenerate it if the format differs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated default Helm chart settings for environment variables, init containers, volume mounts, volumes, and host aliases to use empty lists.
  * Retained the existing empty-map default for resource settings.
  * Improved consistency between documented configuration defaults and supported values.

* **Release**
  * Updated the Kafka UI Helm chart version to 1.6.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->