### PR TITLE
Add configurable lifecycle block with default preStop sleep for graceful pod termination

### DIFF
--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -35,6 +35,7 @@
 | `envs.secretMappings`            | The mapping of existing secret to env variable.                                                                                                    | `{}`  |
 | `envs.configMappings`            | The mapping of configmap and keyName to get env variable.                                                                                          | `{}`  |
 | `env`                            | Envs to be added to the Kafka-UI container                                                                                                         | `[]`  |
+| `lifecycle`                      | Lifecycle hooks for the Kafka-UI container, defaulting to a 5s preStop sleep so endpoints are drained before shutdown. Set `lifecycle: null` to disable | `{}`  |
 | `resources`                      | Set Kafka-UI container requests and limits for different resources like CPU or memory (essential for production workloads)                         | `{}`  |
 | `initContainers`                 | Add additional init containers to the Kafka-UI pods                                                                                                | `[]`  |
 | `volumeMounts`                   | Optionally specify additional volumeMounts for the kafka-UI container                                                                              | `[]`  |

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -137,6 +137,10 @@ spec:
               scheme: HTTPS
               {{- end }}
             {{- toYaml .Values.probes.startup | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.yamlApplicationConfig .Values.volumeMounts .Values.yamlApplicationConfigConfigMap .Values.yamlApplicationConfigSecret }}

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -81,6 +81,19 @@ envs:
 ## @param env [object] Envs to be added to the Kafka-UI container
 env: []
 
+## @param lifecycle [object] Lifecycle hooks for the Kafka-UI container, defaulting to a 5s preStop sleep so endpoints are drained before shutdown. Set `lifecycle: null` to disable
+## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+## Helm merges maps, so `lifecycle: {}` keeps the default below. Use `null` to drop the whole
+## block, or to swap a single handler: --set lifecycle.preStop.exec=null
+##
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - sleep 5
+
 ## @param resources Set Kafka-UI container requests and limits for different resources like CPU or memory (essential for production workloads)
 resources:
   {}


### PR DESCRIPTION
Adds a configurable `lifecycle` block to the kafka-ui container, defaulting to a 5 second `preStop` sleep.

Without it, a terminating pod can still receive traffic: kubelet sends SIGTERM at the same moment the endpoint removal propagates to kube-proxy and ingress controllers, so in-flight requests hit a socket that is already closing. The sleep gives that propagation time to finish before the app shuts down.

- `values.yaml` — new `lifecycle` value with the default `preStop` hook
- `templates/deployment.yaml` — renders it on the main container via `with`, so `lifecycle: {}` omits the block entirely
- `CONFIGURATION.md` — parameter row

`exec: ["/bin/sh", "-c", "sleep 5"]` is used rather than the native `preStop.sleep` handler because the chart declares no `kubeVersion` floor and `PodLifecycleSleepAction` only reached GA in 1.32. Users on newer clusters can switch with `--set lifecycle.preStop.exec=null --set lifecycle.preStop.sleep.seconds=5`; the `exec` must be unset first since Helm deep-merges maps and two handlers in one `preStop` is rejected by the API. This is noted in a comment above the value.

Verified with `helm lint` and `helm template` for the default, the disabled (`lifecycle=null`) and the native-sleep cases.

Note: I left `Chart.yaml` at 1.6.5 since the version bump looks like a maintainer step, so the CI version check will fail until it is bumped — happy to add it here if you would prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Kubernetes container lifecycle hooks to the Kafka UI Helm chart.
  - Included a default 5-second pre-stop delay to allow endpoints to drain before shutdown.
  - Documented the new lifecycle configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->