### PR TITLE
Disable automountServiceAccountToken and support ConfigMap annotations for security hardening

### DIFF
--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -20,6 +20,7 @@
 | `serviceAccount.name`        | The name of the ServiceAccount to use.               | `""`   |
 | `serviceAccount.create`      | Specifies whether a ServiceAccount should be created | `true` |
 | `serviceAccount.annotations` | Additional Service Account annotations               | `{}`   |
+| `serviceAccount.automountServiceAccountToken` | Specifies whether the ServiceAccount token should be automatically mounted into the Kafka-UI pod. Kafka-UI does not call the Kubernetes API by default, so this is disabled to reduce attack surface. | `false` |
 
 ### Application configuration
 

--- a/charts/kafka-ui/CONFIGURATION.md
+++ b/charts/kafka-ui/CONFIGURATION.md
@@ -27,6 +27,7 @@
 | Name                             | Description                                                                                                                                        | Value |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
 | `existingConfigMap`              | Name of the existing ConfigMap with kafbat-ui environment variables                                                                                | `""`  |
+| `configMap.annotations`          | Additional annotations for the ConfigMap(s) created by this chart (e.g. for Vault Agent or other controllers that rely on ConfigMap annotations)   | `{}`  |
 | `yamlApplicationConfig`          | Kafbat-UI config in Yaml format                                                                                                                    | `{}`  |
 | `yamlApplicationConfigConfigMap` | Map with name and keyName keys, name refers to the existing ConfigMap, keyName refers to the ConfigMap key with Kafbat-UI config in Yaml format    | `{}`  |
 | `yamlApplicationConfigSecret`    | Secret with name and keyName keys, name refers to the existing ConfigMap, keyName refers to the ConfigMap key with Kafbat-UI config in Yaml format | `{}`  |

--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.5
+version: 1.6.6
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/configmap.yaml
+++ b/charts/kafka-ui/templates/configmap.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- toYaml .Values.envs.config | nindent 2 }}
 {{- end -}}

--- a/charts/kafka-ui/templates/configmap_fromValues.yaml
+++ b/charts/kafka-ui/templates/configmap_fromValues.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kafka-ui.labels" . | nindent 4 }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   config.yml: |-
     {{- tpl (toYaml .Values.yamlApplicationConfig) . | nindent 4}}

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kafka-ui.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -28,6 +28,8 @@ serviceAccount:
   create: true
   ## @param serviceAccount.annotations Additional Service Account annotations
   annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Specifies whether the ServiceAccount token should be automatically mounted into the Kafka-UI pod. Kafka-UI does not call the Kubernetes API by default, so this is disabled to reduce attack surface.
+  automountServiceAccountToken: false
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
 

--- a/charts/kafka-ui/values.yaml
+++ b/charts/kafka-ui/values.yaml
@@ -36,6 +36,9 @@ serviceAccount:
 ## @section Application configuration
 ## @param existingConfigMap [string] Name of the existing ConfigMap with kafbat-ui environment variables
 existingConfigMap: ""
+## @param configMap.annotations Additional annotations for the ConfigMap(s) created by this chart (e.g. for Vault Agent or other controllers that rely on ConfigMap annotations)
+configMap:
+  annotations: {}
 ## @param yamlApplicationConfig Kafbat-UI config in Yaml format
 yamlApplicationConfig:
   {}


### PR DESCRIPTION
**Background**

Two small, unrelated gaps found while reviewing this chart's security posture:

1. Neither the ServiceAccount resource nor the Deployment's pod spec set automountServiceAccountToken, so every kafka-ui pod gets a Kubernetes API token mounted by default — even though kafka-ui never calls the Kubernetes API in normal operation.

2. Neither ConfigMap this chart creates (configmap.yaml, configmap_fromValues.yaml) supports custom annotations, which blocks integration with tooling that relies on ConfigMap annotations (e.g. HashiCorp Vault Agent), as reported in #72.

**Changes**

- Add serviceAccount.automountServiceAccountToken (default false), wired into the Deployment pod spec.

- Add configMap.annotations (default {}), wired into both ConfigMap templates.

- Bump chart version 1.6.5 → 1.6.6 (single patch bump covering both changes)

- Update CONFIGURATION.md accordingly.

**Reference**

- Closes #73
- Closes #72


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom annotations on ConfigMaps created by the Kafka UI Helm chart.
  * Added configuration to control whether service account tokens are automatically mounted, defaulting to disabled.

* **Documentation**
  * Documented the new ConfigMap annotation and service account token settings.

* **Chores**
  * Updated the Kafka UI Helm chart version to 1.6.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->