### PR TITLE
Fix checksum annotations to hash only config data, not chart metadata

### DIFF
--- a/charts/kafka-ui/Chart.yaml
+++ b/charts/kafka-ui/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: kafka-ui
 description: A Helm chart for kafka-UI
 type: application
-version: 1.6.5
+version: 1.6.6
 appVersion: v1.5.0
 icon: https://raw.githubusercontent.com/kafbat/kafka-ui/main/documentation/images/logo_new.png

--- a/charts/kafka-ui/templates/_helpers.tpl
+++ b/charts/kafka-ui/templates/_helpers.tpl
@@ -82,3 +82,15 @@ This allows us to check if the registry of the image is specified or not.
 {{- end }}
 {{- end -}}
 
+{{/*
+Compute a ConfigMap or Secret checksum from its data only, for the checksum/* pod annotations.
+The full manifest carries the helm.sh/chart label, which changes on every chart version bump.
+The template may render several documents, so hash the data of each one.
+*/}}
+{{- define "kafka-ui.configMapOrSecretContentHash" -}}
+{{- $data := list -}}
+{{- range regexSplit "(?m)^---$" (include (print .ctx.Template.BasePath .name) .ctx) -1 -}}
+{{- $data = append $data (pick (fromYaml .) "data" "stringData") -}}
+{{- end -}}
+{{ $data | toYaml | sha256sum }}
+{{- end -}}

--- a/charts/kafka-ui/templates/deployment.yaml
+++ b/charts/kafka-ui/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
       {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
       {{- end }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        checksum/configFromValues: {{ include (print $.Template.BasePath "/configmap_fromValues.yaml") . | sha256sum }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include "kafka-ui.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmap.yaml") }}
+        checksum/configFromValues: {{ include "kafka-ui.configMapOrSecretContentHash" (dict "ctx" . "name" "/configmap_fromValues.yaml") }}
+        checksum/secret: {{ include "kafka-ui.configMapOrSecretContentHash" (dict "ctx" . "name" "/secret.yaml") }}
       labels:
         {{- include "kafka-ui.selectorLabels" . | nindent 8 }}
         {{- if .Values.podLabels }}


### PR DESCRIPTION
`checksum/config`, `checksum/configFromValues` and `checksum/secret` hash the entire rendered ConfigMap or Secret, and the manifest's `metadata.labels` include `helm.sh/chart`. That value changes on every chart version bump, so the kafka-ui pod is restarted on every `helm upgrade` even when no configuration has changed.

This adds a `kafka-ui.configMapOrSecretContentHash` helper that hashes only the `data`/`stringData` sections and uses it for all three annotations. A pure chart version bump no longer changes the checksums; `envs.config` and `envs.secret` changes still do. Chart bumped to 1.6.6.

The helper splits the rendered output on document separators before hashing, so it stays correct if any of those templates ever renders more than one document.

Verified by rendering the chart against a bumped version with identical values — checksums unchanged — and by setting `envs.config` / `envs.secret`, which still change them. `helm lint` passes.

The same fix was recently made in the argo-cd chart (argoproj/argo-helm#4044) and the opentelemetry-collector chart (open-telemetry/opentelemetry-helm-charts#2402).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment updates when configuration or secret content changes, helping ensure pods restart with the latest settings.
- **Maintenance**
  - Updated the Kafka UI Helm chart version to 1.6.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->